### PR TITLE
Add new functionality Open on Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,23 @@
 
 All notable changes to the "sn-edit" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
 ## [Unreleased]
 - ...
+
+## v0.0.2
+New command "Open on Instance" [#15](https://github.com/sn-edit/vscode/issues/15)
+This command lets you open a currently edited entry on your instance
+I did set up a keyboard shortcut for it.
+
+Here are the combinations per platform:
+Windows: `ctrl+alt+X`
+Linux: `ctrl+alt+X`
+Mac: `shift+cmd+X`
+
+If this shortcut conflicts with something else you are using, you can change it under `File -> Preferences -> Keyboard Shortcuts`. Just search for `sn-edit` and change it as you wish.
+
+You can also run this command through the usual place, under the command palette.
+For this command to work correctly, you need to be inside of a workspace, with a `_config/.sn-edit.yaml` file present. I am reading the information regarding your instance url from this config file. The details should be valid, because this config file is used for downloading/uploading too.
 
 ## v0.0.1
 Initial release of the extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "sn-edit" extension will be documented in this file.
 - ...
 
 ## v0.0.2
+Upgraded dependencies.
 New command "Open on Instance" [#15](https://github.com/sn-edit/vscode/issues/15)
 This command lets you open a currently edited entry on your instance
 I did set up a keyboard shortcut for it.
@@ -18,7 +19,7 @@ Mac: `shift+cmd+X`
 If this shortcut conflicts with something else you are using, you can change it under `File -> Preferences -> Keyboard Shortcuts`. Just search for `sn-edit` and change it as you wish.
 
 You can also run this command through the usual place, under the command palette.
-For this command to work correctly, you need to be inside of a workspace, with a `_config/.sn-edit.yaml` file present. I am reading the information regarding your instance url from this config file. The details should be valid, because this config file is used for downloading/uploading too.
+For this command to work correctly, you need to be inside of a workspace, with a `_config/.sn-edit.yaml` file present. I am reading the information regarding your instance url from this config file. The details should be valid, because this config file is used for downloading/uploading too. 
 
 ## v0.0.1
 Initial release of the extension

--- a/commands/open-on-instance.js
+++ b/commands/open-on-instance.js
@@ -1,5 +1,4 @@
 const vscode = require('vscode');
-// const { runCommand } = require("../helpers/commands");
 const fs = require('fs');
 const yaml = require('js-yaml');
 const { initExtension } = require('../core/config');

--- a/commands/open-on-instance.js
+++ b/commands/open-on-instance.js
@@ -20,9 +20,6 @@ const openOnInstanceCMD = async () => {
     } catch (e) {
         data = null;
         console.log(e);
-        return vscode.window.showErrorMessage(
-			"Error while reading the config file! Please check permissions and try again!"
-		);
     }
 
     if (!data || !data["app"]["core"]["rest"]["url"]) {

--- a/commands/open-on-instance.js
+++ b/commands/open-on-instance.js
@@ -1,0 +1,46 @@
+const vscode = require('vscode');
+// const { runCommand } = require("../helpers/commands");
+const fs = require('fs');
+const yaml = require('js-yaml');
+const { initExtension } = require('../core/config');
+const { getSysID, getTable } = require('../helpers/core');
+
+const openOnInstanceCMD = async () => {
+    const engine = initExtension();
+    
+    if (engine.error) {
+        return;
+    }
+    let data = {};
+
+    try {
+        let fileContents = fs.readFileSync(engine.workspacePath + '/_config/.sn-edit.yaml', 'utf8');
+        data = yaml.safeLoad(fileContents);
+    
+        console.log(data);
+    } catch (e) {
+        data = null;
+        console.log(e);
+        return vscode.window.showErrorMessage(
+			"Error while reading the config file! Please check permissions and try again!"
+		);
+    }
+
+    if (!data || !data["app"]["core"]["rest"]["url"]) {
+        return vscode.window.showErrorMessage(
+			"Could not get instance information from your config file! Please check and try again!"
+		);
+    }
+
+    // open url
+    let editor = vscode.window.activeTextEditor;
+    let instanceURL = data["app"]["core"]["rest"]["url"];
+    let sysID = getSysID(editor);
+    let tableName = getTable(editor);
+
+    vscode.env.openExternal(vscode.Uri.parse(instanceURL + "/" + tableName + ".do?sys_id=" + sysID));
+};
+
+module.exports = {
+    openOnInstanceCMD: openOnInstanceCMD
+}

--- a/extension.js
+++ b/extension.js
@@ -8,6 +8,7 @@ const { updateStatusBarItem } = require('./commands/display-updateset');
 const { versionCommand } = require('./commands/version');
 const { searchCMD } = require('./commands/search');
 const { downloadCMD } = require('./commands/download');
+const { openOnInstanceCMD } = require('./commands/open-on-instance');
 const { runCommand } = require("./helpers/commands");
 const { tryParseJSON } = require('./helpers/json');
 const { setStatusbarMessage } = require('./helpers/statusbar');
@@ -21,6 +22,9 @@ function activate(context) {
 	const { subscriptions } = context;
 	/* Download */
 	subscriptions.push(vscode.commands.registerCommand('sn-edit.download', downloadCMD));
+
+	/* Open on Instance */
+	subscriptions.push(vscode.commands.registerCommand('sn-edit.openOnInstance', openOnInstanceCMD));
 
 	// upload onsave
 	vscode.workspace.onDidSaveTextDocument(async (editor) => {

--- a/helpers/core.js
+++ b/helpers/core.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const path = require("path");
+const fs = require('fs');
 
 const getFieldName = (editor) => {
     let fileBaseName = path.basename(editor.fileName);
@@ -11,7 +12,7 @@ const getFieldName = (editor) => {
 const getTable = (editor) => {
     let table = "";
 
-    let currentFileName = editor.fileName;
+    let currentFileName = editor.fileName ? editor.fileName : editor.document.uri.fsPath;
     // split the file path based on the current OS's separator, windows and unix like differ
     currentFileName = currentFileName.split(path.sep);
 
@@ -37,8 +38,30 @@ const getScope = (editor) => {
     return scopeName;
 };
 
+const getSysID = (editor) => {
+    console.log("Editor", editor.fileName, editor.document.uri.fspat);
+    let currentFileName = editor.fileName ? editor.fileName : editor.document.uri.fsPath;
+    // split the file path based on the current OS's separator, windows and unix like differ
+    currentFileName = currentFileName.split(path.sep);
+    let name = "";
+
+    if (currentFileName[currentFileName.length - 4].length > 0) {
+        name = currentFileName[currentFileName.length - 2];
+    }
+
+    let folderPath = currentFileName;
+    folderPath.splice(folderPath.length -1, 1);
+    folderPath = folderPath.join(path.sep);
+    let sysIDPath = folderPath + path.sep + "sys_id.txt";
+    // TODO, introduce some validation if path exists and there was any error
+    let sysID = fs.readFileSync(sysIDPath).toString();
+
+    return sysID;
+}
+
 module.exports = {
     getFieldName: getFieldName,
     getTable: getTable,
-    getScope: getScope
+    getScope: getScope,
+    getSysID: getSysID,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,15 +59,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-			"integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+			"version": "13.13.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.19.tgz",
+			"integrity": "sha512-IVsULCpTdafcHhBDLYEPnV5l15xV0q065zvOHC1ZmzFYaBCMzku078eXnazoSG8907vZjRgEN/EQjku7GwwFyQ==",
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-			"integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
+			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
 			"dev": true
 		},
 		"acorn": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "SN-EDIT - Servicenow Editor engine",
 	"description": "Servicenow Editor Engine (sn-edit)",
 	"publisher": "snedit",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"icon": "images/sn-edit-logo.png",
 	"bugs": {
 		"url": "https://github.com/sn-edit/vscode/issues"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"*",
 		"onCommand:sn-edit.download",
 		"onCommand:sn-edit.version",
+		"onCommand:sn-edit.openOnInstance",
 		"onCommand:snedit.changeUpdateSet"
 	],
 	"main": "./extension.js",
@@ -40,13 +41,24 @@
 		"commands": [
 			{
 				"command": "sn-edit.download",
-				"title": "sn-edit Download Script"
+				"title": "sn-edit: Download Script"
 			},
 			{
 				"command": "sn-edit.version",
-				"title": "sn-edit Version"
+				"title": "sn-edit: Version"
+			},
+			{
+				"command": "sn-edit.openOnInstance",
+				"title": "sn-edit: Open entry on the instance"
 			}
-		]
+		],
+		"keybindings": [
+            {
+                "command": "sn-edit.openOnInstance",
+                "key": "ctrl+alt+X",
+                "mac": "shift+cmd+X"
+            }
+        ]
 	},
 	"scripts": {
 		"lint": "eslint .",
@@ -56,8 +68,8 @@
 	"devDependencies": {
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^13.13.15",
-		"@types/vscode": "^1.47.0",
+		"@types/node": "^13.13.19",
+		"@types/vscode": "^1.49.0",
 		"eslint": "^6.8.0",
 		"glob": "^7.1.6",
 		"mocha": "^7.1.1",
@@ -66,7 +78,7 @@
 	},
 	"dependencies": {
 		"curlrequest": "^1.0.1",
-		"js-yaml": "^3.13.1",
+		"js-yaml": "^3.14.0",
 		"shelljs": "^0.8.4"
 	}
 }


### PR DESCRIPTION
Added the feature that allows you to open the entry record which you are currently editing locally.

You can now easily open the entry you are editing in the browser on your own instance. This makes it easy to check if everything works correctly.

Keyboard shortcuts have been also added to make it easy to call the command:
Windows: `ctrl+alt+X`
Linux: `ctrl+alt+X`
Mac: `shift+cmd+X`

If this shortcut conflicts with something else you are using, you can change it under `File -> Preferences -> Keyboard Shortcuts`. Just search for `sn-edit` and change it as you wish.